### PR TITLE
Change text color to black on inputs where background is white

### DIFF
--- a/dist/AmpliPi-HomeAssistant-Card.js
+++ b/dist/AmpliPi-HomeAssistant-Card.js
@@ -1019,11 +1019,6 @@ class CommonAmplipiCardEditor extends LitElement {
             padding: 16px;
             border: none;
             border-radius: 12px;
-            background-color: #DDDDDD;
-        }
-        
-        select:hover {
-            background-color: #CCCCCC;
         }
 
         input{
@@ -1031,7 +1026,6 @@ class CommonAmplipiCardEditor extends LitElement {
             padding: 16px;
             border: none;
             border-bottom: 2px solid blue;
-            background-color: #FFFFFF;
         }
     `;
 }

--- a/src/common-amplipi-editor.js
+++ b/src/common-amplipi-editor.js
@@ -53,11 +53,9 @@ export class CommonAmplipiCardEditor extends LitElement {
             padding: 16px;
             border: none;
             border-radius: 12px;
-            background-color: #DDDDDD;
         }
         
         select:hover {
-            background-color: #CCCCCC;
         }
 
         input{
@@ -65,7 +63,6 @@ export class CommonAmplipiCardEditor extends LitElement {
             padding: 16px;
             border: none;
             border-bottom: 2px solid blue;
-            background-color: #FFFFFF;
         }
     `;
 }


### PR DESCRIPTION
We were forcefully overriding light and dark theming, but only partially; I wasn't able to fully override it by changing the font color so I stopped overriding it at all