### PR TITLE
Source Selection with Stream Entities

### DIFF
--- a/dist/AmpliPi-HomeAssistant-Card.js
+++ b/dist/AmpliPi-HomeAssistant-Card.js
@@ -850,7 +850,7 @@ class CommonAmplipiCard extends LitElement {
         var source_id;
         if (!is_source) {
             const source_num = source.split(" ")[1] - 1;
-            for (var [name, entity] of Object.entries(this._hass.states))if (entity.attributes.amplipi_source_id !== undefined && entity.attributes.amplipi_source_id === source_num) source_id = name;
+            for (var [name, entity] of Object.entries(this._hass.states))if (entity.attributes.device_class == "receiver" && entity.attributes.amplipi_source_id !== undefined && entity.attributes.amplipi_source_id === source_num) source_id = name;
         } else source_id = source;
         let source_player_config1 = {
             "type": "custom:mini-media-player",

--- a/dist/AmpliPi-HomeAssistant-Card.js
+++ b/dist/AmpliPi-HomeAssistant-Card.js
@@ -850,7 +850,7 @@ class CommonAmplipiCard extends LitElement {
         var source_id;
         if (!is_source) {
             const source_num = source.split(" ")[1] - 1;
-            for (var [name, entity] of Object.entries(this._hass.states))if (entity.attributes.device_class == "receiver" && entity.attributes.amplipi_source_id !== undefined && entity.attributes.amplipi_source_id === source_num) source_id = name;
+            for (var [name, entity] of Object.entries(this._hass.states))if (entity.attributes.device_class == "source" && entity.attributes.amplipi_source_id !== undefined && entity.attributes.amplipi_source_id === source_num) source_id = name;
         } else source_id = source;
         let source_player_config1 = {
             "type": "custom:mini-media-player",

--- a/src/common-amplipi-card.js
+++ b/src/common-amplipi-card.js
@@ -73,7 +73,7 @@ export class CommonAmplipiCard extends LitElement {
         if(!is_source) {
             const source_num = source.split(' ')[1] - 1;
             for (var [name, entity] of Object.entries(this._hass.states)) {
-                if (entity.attributes.device_class == "receiver"
+                if (entity.attributes.device_class == "source"
                     && entity.attributes.amplipi_source_id !== undefined
                     && entity.attributes.amplipi_source_id === source_num
                 ) {

--- a/src/common-amplipi-card.js
+++ b/src/common-amplipi-card.js
@@ -73,7 +73,8 @@ export class CommonAmplipiCard extends LitElement {
         if(!is_source) {
             const source_num = source.split(' ')[1] - 1;
             for (var [name, entity] of Object.entries(this._hass.states)) {
-                if(entity.attributes.amplipi_source_id !== undefined 
+                if (entity.attributes.device_class == "receiver"
+                    && entity.attributes.amplipi_source_id !== undefined
                     && entity.attributes.amplipi_source_id === source_num
                 ) {
                     source_id = name;


### PR DESCRIPTION
Creating full stream entities screwed up how sources and streams are selected on the zone and group cards; the entity.source_list was being selected from streams (which contains a list of the four sources) rather than sources (which contains a list of all streams) due to the new stream entities having some data shared with sources that caused a check to pass when it shouldn't have

In this PR I change that check to ensure that you're selecting a source instead of a stream to then select the source list from